### PR TITLE
Message pagination

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -760,8 +760,29 @@ var doc = `{
                     },
                     {
                         "type": "string",
-                        "description": "Last timestamp of received message",
-                        "name": "timestamp",
+                        "description": "Date from which pagination will be performed (date format RFC3339Nano)",
+                        "name": "offset_date",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Pagination direction (newer or older)",
+                        "name": "direction",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Number of result to return",
+                        "name": "limit",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Number of messages to be skipped",
+                        "name": "offset",
                         "in": "query",
                         "required": true
                     }
@@ -1440,11 +1461,20 @@ var doc = `{
         "http.MessageListResponse": {
             "type": "object",
             "properties": {
-                "list": {
+                "has_next": {
+                    "type": "boolean"
+                },
+                "has_prev": {
+                    "type": "boolean"
+                },
+                "result": {
                     "type": "array",
                     "items": {
                         "$ref": "#/definitions/domain.Message"
                     }
+                },
+                "total": {
+                    "type": "integer"
                 }
             }
         },

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -746,8 +746,29 @@
                     },
                     {
                         "type": "string",
-                        "description": "Last timestamp of received message",
-                        "name": "timestamp",
+                        "description": "Date from which pagination will be performed (date format RFC3339Nano)",
+                        "name": "offset_date",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Pagination direction (newer or older)",
+                        "name": "direction",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Number of result to return",
+                        "name": "limit",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Number of messages to be skipped",
+                        "name": "offset",
                         "in": "query",
                         "required": true
                     }
@@ -1426,11 +1447,20 @@
         "http.MessageListResponse": {
             "type": "object",
             "properties": {
-                "list": {
+                "has_next": {
+                    "type": "boolean"
+                },
+                "has_prev": {
+                    "type": "boolean"
+                },
+                "result": {
                     "type": "array",
                     "items": {
                         "$ref": "#/definitions/domain.Message"
                     }
+                },
+                "total": {
+                    "type": "integer"
                 }
             }
         },

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -213,10 +213,16 @@ definitions:
     type: object
   http.MessageListResponse:
     properties:
-      list:
+      has_next:
+        type: boolean
+      has_prev:
+        type: boolean
+      result:
         items:
           $ref: '#/definitions/domain.Message'
         type: array
+      total:
+        type: integer
     type: object
   http.ResponseError:
     properties:
@@ -705,11 +711,26 @@ paths:
         name: chat_id
         required: true
         type: string
-      - description: Last timestamp of received message
+      - description: Date from which pagination will be performed (date format RFC3339Nano)
         in: query
-        name: timestamp
+        name: offset_date
         required: true
         type: string
+      - description: Pagination direction (newer or older)
+        in: query
+        name: direction
+        required: true
+        type: string
+      - description: Number of result to return
+        in: query
+        name: limit
+        required: true
+        type: integer
+      - description: Number of messages to be skipped
+        in: query
+        name: offset
+        required: true
+        type: integer
       produces:
       - application/json
       responses:

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -84,10 +84,7 @@ func NewApp(cfg *config.Config) *App {
 		app.redisClient,
 	)
 	sessionRepo := repository.NewSessionRedisRepository(app.redisClient)
-	msgRepo := repository.NewMessageCompositeRepository(
-		repository.NewMessageRedisRepository(app.redisClient),
-		repository.NewMessagePostgresRepository(app.dbPool),
-	)
+	msgRepo := repository.NewMessageRedisRepository(app.redisClient)
 
 	userService := service.NewUserService(userRepo, sessionRepo, hasher)
 	chatService := service.NewChatService(chatRepo)

--- a/internal/delivery/http/messages.go
+++ b/internal/delivery/http/messages.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Mort4lis/scht-backend/internal/encoding"
 	"github.com/Mort4lis/scht-backend/internal/service"
 	"github.com/Mort4lis/scht-backend/pkg/logging"
+	"github.com/Mort4lis/scht-backend/pkg/paginator"
 	"github.com/Mort4lis/scht-backend/pkg/validator"
 	"github.com/julienschmidt/httprouter"
 )
@@ -19,8 +20,18 @@ const (
 	listChatMessageURI = "/api/chats/:chat_id/messages"
 )
 
+const (
+	offsetDateQuery = "offset_date"
+	directionQuery  = "direction"
+	limitQuery      = "limit"
+	offsetQuery     = "offset"
+)
+
 type MessageListResponse struct {
-	List []domain.Message `json:"list"`
+	Total   int              `json:"total"`
+	HasNext bool             `json:"has_next"`
+	HasPrev bool             `json:"has_prev"`
+	Result  []domain.Message `json:"result"`
 }
 
 func (r MessageListResponse) Marshal() ([]byte, error) {
@@ -50,29 +61,52 @@ func (h *messageHandler) register(router *httprouter.Router, authMid Middleware)
 // @Accept json
 // @Produce json
 // @Param chat_id path string true "Chat id"
-// @Param timestamp query string true "Last timestamp of received message"
+// @Param offset_date query string true "Date from which pagination will be performed (date format RFC3339Nano)"
+// @Param direction query string true "Direction of pagination towards newer or older messages"
+// @Param limit query int true "Number of result to return"
+// @Param offset query int true "Number of messages to be skipped"
 // @Success 200 {object} MessageListResponse
 // @Failure 400,404 {object} ResponseError
 // @Failure 500 {object} ResponseError
 // @Router /chats/{chat_id}/messages [get]
 func (h *messageHandler) list(w http.ResponseWriter, req *http.Request) {
 	ctx := req.Context()
+	query := req.URL.Query()
 	ps := httprouter.ParamsFromContext(ctx)
-	chatID, tsRaw := ps.ByName(chatIDParam), req.URL.Query().Get("timestamp")
+
+	chatID := ps.ByName(chatIDParam)
+	offsetDateStr := query.Get(offsetDateQuery)
+	direction := query.Get(directionQuery)
+	limitStr := query.Get(limitQuery)
+	offsetStr := query.Get(offsetQuery)
 
 	logger := logging.GetLoggerFromContext(ctx).WithFields(logging.Fields{
-		"chat_id":   chatID,
-		"timestamp": tsRaw,
+		chatIDParam:     chatID,
+		offsetDateQuery: offsetDateStr,
+		directionQuery:  direction,
+		limitQuery:      limitStr,
+		offsetQuery:     offsetStr,
 	})
 	ctx = logging.NewContextFromLogger(ctx, logger)
 
-	timeValidator := validator.NewTimeValidator("timestamp", tsRaw, time.RFC3339Nano)
+	offsetDateValidator := validator.NewTimeValidator(offsetDateQuery, offsetDateStr, time.RFC3339Nano, false)
+	limitValidator := validator.NewIntValidator(limitQuery, limitStr, false)
+	offsetValidator := validator.NewIntValidator(offsetQuery, offsetStr, false)
+
 	vl := validator.ChainValidator(
 		validator.UUIDValidator(chatIDParam, chatID),
-		timeValidator,
+		offsetDateValidator,
+		limitValidator,
+		offsetValidator,
 	)
 
 	if err := h.validate(vl); err != nil {
+		respondError(ctx, w, err)
+		return
+	}
+
+	dto := domain.NewMessageListDTO(offsetDateValidator.Value(), direction, limitValidator.Value(), offsetValidator.Value())
+	if err := h.validate(validator.StructValidator(dto)); err != nil {
 		respondError(ctx, w, err)
 		return
 	}
@@ -83,7 +117,7 @@ func (h *messageHandler) list(w http.ResponseWriter, req *http.Request) {
 		ChatID: chatID,
 	}
 
-	messages, err := h.msgService.List(ctx, memberKey, timeValidator.Value())
+	messageList, err := h.msgService.List(ctx, memberKey, dto)
 	if err != nil {
 		switch {
 		case errors.Is(err, domain.ErrChatNotFound):
@@ -95,7 +129,19 @@ func (h *messageHandler) list(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	respondSuccess(ctx, http.StatusOK, w, MessageListResponse{List: messages})
+	paginate := paginator.LimitOffsetPaginate{
+		Total:  messageList.Total,
+		Count:  len(messageList.Messages),
+		Limit:  limitValidator.Value(),
+		Offset: offsetValidator.Value(),
+	}
+
+	respondSuccess(ctx, http.StatusOK, w, MessageListResponse{
+		Total:   messageList.Total,
+		HasNext: paginate.HasNext(),
+		HasPrev: paginate.HasPrev(),
+		Result:  messageList.Messages,
+	})
 }
 
 // @Summary Send message to the chat

--- a/internal/delivery/http/messages.go
+++ b/internal/delivery/http/messages.go
@@ -62,7 +62,7 @@ func (h *messageHandler) register(router *httprouter.Router, authMid Middleware)
 // @Produce json
 // @Param chat_id path string true "Chat id"
 // @Param offset_date query string true "Date from which pagination will be performed (date format RFC3339Nano)"
-// @Param direction query string true "Direction of pagination towards newer or older messages"
+// @Param direction query string true "Pagination direction (newer or older)"
 // @Param limit query int true "Number of result to return"
 // @Param offset query int true "Number of messages to be skipped"
 // @Success 200 {object} MessageListResponse

--- a/internal/domain/message.go
+++ b/internal/domain/message.go
@@ -11,6 +11,39 @@ const (
 	MessageKickAction
 )
 
+const (
+	NewerMessages = "newer"
+	OlderMessages = "older"
+)
+
+const defaultListMessages = 20
+
+type MessageListDTO struct {
+	OffsetDate time.Time
+	Direction  string `json:"direction" validate:"oneof=newer older"`
+	Limit      int    `json:"limit"     validate:"gte=0,lte=100"`
+	Offset     int    `json:"offset"    validate:"gte=0"`
+}
+
+func NewMessageListDTO(offsetDate time.Time, direction string, limit, offset int) MessageListDTO {
+	dto := MessageListDTO{
+		OffsetDate: offsetDate,
+		Direction:  direction,
+		Limit:      limit,
+		Offset:     offset,
+	}
+
+	if dto.Direction == "" {
+		dto.Direction = NewerMessages
+	}
+
+	if dto.Limit == 0 {
+		dto.Limit = defaultListMessages
+	}
+
+	return dto
+}
+
 type CreateMessageDTO struct {
 	ActionID int    `json:"-"`
 	Text     string `json:"text"    validate:"required,max=4096"`
@@ -25,4 +58,9 @@ type Message struct {
 	ChatID    string     `json:"chat_id"`
 	SenderID  string     `json:"sender_id"`
 	CreatedAt *time.Time `json:"created_at"`
+}
+
+type MessageList struct {
+	Total    int
+	Messages []Message
 }

--- a/internal/repository/message_composite.go
+++ b/internal/repository/message_composite.go
@@ -2,7 +2,6 @@ package repository
 
 import (
 	"context"
-	"time"
 
 	"github.com/Mort4lis/scht-backend/internal/domain"
 	"github.com/Mort4lis/scht-backend/pkg/logging"
@@ -24,18 +23,18 @@ func (r *messageCompositeRepository) Create(ctx context.Context, dto domain.Crea
 	return r.cacheRepo.Create(ctx, dto)
 }
 
-func (r *messageCompositeRepository) List(ctx context.Context, chatID string, timestamp time.Time) ([]domain.Message, error) {
-	messages, err := r.cacheRepo.List(ctx, chatID, timestamp)
+func (r *messageCompositeRepository) List(ctx context.Context, chatID string, dto domain.MessageListDTO) (domain.MessageList, error) {
+	messageList, err := r.cacheRepo.List(ctx, chatID, dto)
 	if err != nil {
-		return nil, err
+		return domain.MessageList{}, err
 	}
 
-	if len(messages) != 0 {
-		return messages, err
+	if len(messageList.Messages) != 0 {
+		return messageList, err
 	}
 
 	logger := logging.GetLoggerFromContext(ctx)
 	logger.Debug("not found messages into the cache for chat, going to the database...")
 
-	return r.dbRepo.List(ctx, chatID, timestamp)
+	return r.dbRepo.List(ctx, chatID, dto)
 }

--- a/internal/repository/message_postgres.go
+++ b/internal/repository/message_postgres.go
@@ -1,6 +1,7 @@
 package repository
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 
@@ -20,14 +21,9 @@ func (r *messagePostgresRepository) Create(ctx context.Context, dto domain.Creat
 }
 
 func (r *messagePostgresRepository) List(ctx context.Context, chatID string, dto domain.MessageListDTO) (domain.MessageList, error) {
-	query := `SELECT 
-		id, action_id, text, 
-		sender_id, chat_id, created_at 
-	FROM messages 
-	WHERE chat_id = $1 AND created_at > $2 
-	ORDER BY created_at`
+	query := r.buildListQuery(dto.Direction)
 
-	rows, err := r.dbPool.Query(ctx, query, chatID, dto.OffsetDate)
+	rows, err := r.dbPool.Query(ctx, query, chatID, dto.OffsetDate, dto.Offset, dto.Limit)
 	if err != nil {
 		return domain.MessageList{}, fmt.Errorf("an error occurred while querying list of messages from database: %v", err)
 	}
@@ -52,5 +48,56 @@ func (r *messagePostgresRepository) List(ctx context.Context, chatID string, dto
 		return domain.MessageList{}, fmt.Errorf("an error occurred while reading messages: %v", err)
 	}
 
-	return domain.MessageList{Messages: messages}, nil
+	total, err := r.getTotalMessages(ctx, chatID, dto)
+	if err != nil {
+		return domain.MessageList{}, err
+	}
+
+	return domain.MessageList{
+		Total:    total,
+		Messages: messages,
+	}, nil
+}
+
+func (r *messagePostgresRepository) getTotalMessages(ctx context.Context, chatID string, dto domain.MessageListDTO) (int, error) {
+	total := 0
+	builder := bytes.NewBufferString(`SELECT COUNT(*) as total FROM messages WHERE chat_id = $1 AND `)
+
+	if dto.Direction == domain.NewerMessages {
+		builder.WriteString("created_at >= $2")
+	} else {
+		builder.WriteString("created_at <= $2")
+	}
+
+	if err := r.dbPool.QueryRow(ctx, builder.String(), chatID, dto.OffsetDate).Scan(&total); err != nil {
+		return total, fmt.Errorf("an error occurred while getting total messages: %v", err)
+	}
+
+	return total, nil
+}
+
+func (r *messagePostgresRepository) buildListQuery(direction string) string {
+	builder := bytes.NewBufferString(`SELECT 
+		id, action_id, text, 
+		sender_id, chat_id, created_at 
+	FROM messages 
+	WHERE chat_id = $1 AND `)
+
+	if direction == domain.NewerMessages {
+		builder.WriteString("created_at >= $2")
+	} else {
+		builder.WriteString("created_at <= $2")
+	}
+
+	builder.WriteString(" ORDER BY created_at ")
+
+	if direction == domain.NewerMessages {
+		builder.WriteString("ASC")
+	} else {
+		builder.WriteString("DESC")
+	}
+
+	builder.WriteString(" OFFSET $3 LIMIT $4")
+
+	return builder.String()
 }

--- a/internal/repository/message_redis.go
+++ b/internal/repository/message_redis.go
@@ -47,15 +47,43 @@ func (r *messageRedisRepository) Create(ctx context.Context, dto domain.CreateMe
 	return message, nil
 }
 
-func (r *messageRedisRepository) List(ctx context.Context, chatID string, timestamp time.Time) ([]domain.Message, error) {
+func (r *messageRedisRepository) List(ctx context.Context, chatID string, dto domain.MessageListDTO) (domain.MessageList, error) {
+	min, max := "-inf", "+inf"
 	key := fmt.Sprintf("chat:%s:messages", chatID)
+	offsetDateUnixNano := fmt.Sprintf("%d", dto.OffsetDate.UnixNano())
+
+	if dto.Direction == domain.NewerMessages {
+		min = offsetDateUnixNano
+	} else {
+		max = offsetDateUnixNano
+	}
+
+	total, err := r.redisClient.ZCount(ctx, key, min, max).Result()
+	if err != nil {
+		return domain.MessageList{}, fmt.Errorf("an error occurred while calculating total messages: %v", err)
+	}
+
+	limit, offset := dto.Limit, dto.Offset
+	if dto.Direction == domain.OlderMessages {
+		offset = int(total) - dto.Limit - offset
+		if offset < 0 {
+			offset = 0
+			limit = int(total) - dto.Offset
+		}
+
+		if limit <= 0 {
+			return domain.MessageList{Total: int(total)}, nil
+		}
+	}
 
 	payloads, err := r.redisClient.ZRangeByScore(ctx, key, &redis.ZRangeBy{
-		Min: fmt.Sprintf("(%d", timestamp.UnixNano()),
-		Max: "+inf",
+		Min:    min,
+		Max:    max,
+		Offset: int64(offset),
+		Count:  int64(limit),
 	}).Result()
 	if err != nil {
-		return nil, fmt.Errorf("an error occurred while getting list of messages: %v", err)
+		return domain.MessageList{}, fmt.Errorf("an error occurred while getting list of messages: %v", err)
 	}
 
 	messages := make([]domain.Message, 0, len(payloads))
@@ -64,11 +92,14 @@ func (r *messageRedisRepository) List(ctx context.Context, chatID string, timest
 		var message domain.Message
 
 		if err = encoding.NewProtobufMessageUnmarshaler(&message).Unmarshal([]byte(payload)); err != nil {
-			return nil, fmt.Errorf("an error occurred while unmarshaling the message: %v", err)
+			return domain.MessageList{}, fmt.Errorf("an error occurred while unmarshaling the message: %v", err)
 		}
 
 		messages = append(messages, message)
 	}
 
-	return messages, nil
+	return domain.MessageList{
+		Total:    int(total),
+		Messages: messages,
+	}, nil
 }

--- a/internal/repository/message_redis.go
+++ b/internal/repository/message_redis.go
@@ -94,7 +94,7 @@ func (r *messageRedisRepository) List(ctx context.Context, chatID string, dto do
 
 	total, err := r.redisClient.ZCount(ctx, key, min, max).Result()
 	if err != nil {
-		return domain.MessageList{}, fmt.Errorf("an error occurred while calculating total messages: %v", err)
+		return domain.MessageList{}, fmt.Errorf("an error occurred while getting total messages: %v", err)
 	}
 
 	return domain.MessageList{

--- a/internal/repository/repository.go
+++ b/internal/repository/repository.go
@@ -46,7 +46,7 @@ type ChatMemberRepository interface {
 
 type MessageRepository interface {
 	Create(ctx context.Context, dto domain.CreateMessageDTO) (domain.Message, error)
-	List(ctx context.Context, chatID string, timestamp time.Time) ([]domain.Message, error)
+	List(ctx context.Context, chatID string, dto domain.MessageListDTO) (domain.MessageList, error)
 }
 
 type MessagePubSub interface {

--- a/internal/service/message.go
+++ b/internal/service/message.go
@@ -3,7 +3,6 @@ package service
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/Mort4lis/scht-backend/internal/domain"
 	"github.com/Mort4lis/scht-backend/internal/repository"
@@ -81,19 +80,19 @@ func (s *messageService) Create(ctx context.Context, dto domain.CreateMessageDTO
 	return message, nil
 }
 
-func (s *messageService) List(ctx context.Context, memberKey domain.ChatMemberIdentity, timestamp time.Time) ([]domain.Message, error) {
+func (s *messageService) List(ctx context.Context, memberKey domain.ChatMemberIdentity, dto domain.MessageListDTO) (domain.MessageList, error) {
 	ok, err := s.chatMemberRepo.IsInChat(ctx, memberKey)
 	if err != nil {
-		return nil, fmt.Errorf("failed to check if member is in the chat: %w", err)
+		return domain.MessageList{}, fmt.Errorf("failed to check if member is in the chat: %w", err)
 	}
 
 	if !ok {
-		return nil, fmt.Errorf("member isn't in this chat: %w", domain.ErrChatNotFound)
+		return domain.MessageList{}, fmt.Errorf("member isn't in this chat: %w", domain.ErrChatNotFound)
 	}
 
-	messages, err := s.messageRepo.List(ctx, memberKey.ChatID, timestamp)
+	messages, err := s.messageRepo.List(ctx, memberKey.ChatID, dto)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get list of messages: %w", err)
+		return domain.MessageList{}, fmt.Errorf("failed to get list of messages: %w", err)
 	}
 
 	return messages, nil

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -2,7 +2,6 @@ package service
 
 import (
 	"context"
-	"time"
 
 	"github.com/Mort4lis/scht-backend/internal/domain"
 )
@@ -51,7 +50,7 @@ type MessageService interface {
 	NewServeSession(ctx context.Context, userID string) (inCh chan<- domain.CreateMessageDTO, outCh <-chan domain.Message, errCh <-chan error, err error)
 	Create(ctx context.Context, dto domain.CreateMessageDTO) (domain.Message, error)
 	// List gets a list of chat messages with timestamp if accepted member consists in this chat.
-	List(ctx context.Context, memberKey domain.ChatMemberIdentity, timestamp time.Time) ([]domain.Message, error)
+	List(ctx context.Context, memberKey domain.ChatMemberIdentity, dto domain.MessageListDTO) (domain.MessageList, error)
 }
 
 type ServiceContainer struct {

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -49,7 +49,7 @@ type ChatMemberService interface {
 type MessageService interface {
 	NewServeSession(ctx context.Context, userID string) (inCh chan<- domain.CreateMessageDTO, outCh <-chan domain.Message, errCh <-chan error, err error)
 	Create(ctx context.Context, dto domain.CreateMessageDTO) (domain.Message, error)
-	// List gets a list of chat messages with timestamp if accepted member consists in this chat.
+	// List gets a list of chat messages if accepted member consists in this chat.
 	List(ctx context.Context, memberKey domain.ChatMemberIdentity, dto domain.MessageListDTO) (domain.MessageList, error)
 }
 

--- a/pkg/paginator/limit_offset.go
+++ b/pkg/paginator/limit_offset.go
@@ -1,0 +1,16 @@
+package paginator
+
+type LimitOffsetPaginate struct {
+	Total  int
+	Count  int
+	Limit  int
+	Offset int
+}
+
+func (p LimitOffsetPaginate) HasNext() bool {
+	return p.Total > 0 && p.Offset+p.Count < p.Total
+}
+
+func (p LimitOffsetPaginate) HasPrev() bool {
+	return p.Total > 0 && p.Offset > 0
+}

--- a/pkg/paginator/paginator.go
+++ b/pkg/paginator/paginator.go
@@ -1,0 +1,6 @@
+package paginator
+
+type Paginate interface {
+	HasNext() bool
+	HasPrev() bool
+}

--- a/pkg/validator/int.go
+++ b/pkg/validator/int.go
@@ -1,0 +1,41 @@
+package validator
+
+import "strconv"
+
+type IntValidator struct {
+	Field    string
+	RawValue string
+	Required bool
+	parsed   int
+}
+
+func (v *IntValidator) Validate() error {
+	if !v.Required && v.RawValue == "" {
+		return nil
+	}
+
+	parsed, err := strconv.Atoi(v.RawValue)
+	if err != nil {
+		return ValidationError{
+			Fields: ErrorFields{
+				v.Field: "must be integer",
+			},
+		}
+	}
+
+	v.parsed = parsed
+
+	return nil
+}
+
+func (v *IntValidator) Value() int {
+	return v.parsed
+}
+
+func NewIntValidator(field, value string, required bool) *IntValidator {
+	return &IntValidator{
+		Field:    field,
+		RawValue: value,
+		Required: required,
+	}
+}

--- a/pkg/validator/time.go
+++ b/pkg/validator/time.go
@@ -8,10 +8,15 @@ type TimeValidator struct {
 	Field    string
 	RawValue string
 	Layout   string
+	Required bool
 	parsed   time.Time
 }
 
 func (v *TimeValidator) Validate() error {
+	if !v.Required && v.RawValue == "" {
+		return nil
+	}
+
 	parsed, err := time.Parse(v.Layout, v.RawValue)
 	if err != nil {
 		return ValidationError{
@@ -30,10 +35,11 @@ func (v *TimeValidator) Value() time.Time {
 	return v.parsed
 }
 
-func NewTimeValidator(field, value, layout string) *TimeValidator {
+func NewTimeValidator(field, value, layout string, required bool) *TimeValidator {
 	return &TimeValidator{
 		Field:    field,
 		RawValue: value,
 		Layout:   layout,
+		Required: required,
 	}
 }


### PR DESCRIPTION
Now you can paginate chat message using the requests described below:

1. Get 5 newer messages from date **2022-01-26 19:33:00** from the beginning
`http://127.0.0.1:8000/api/chats/92fe4376-a502-4ae1-a5f8-21c1945ca2b7/messages?offset_date=2022-01-26T10%3A33%3A00Z&direction=newer&limit=5&offset=0`
2. Get 5 older messages from date **2022-01-26 18:33:00** from the end skipped 5 messages
`http://127.0.0.1:8000/api/chats/92fe4376-a502-4ae1-a5f8-21c1945ca2b7/messages?offset_date=2022-01-26T18%3A33%3A00Z&direction=older&limit=5&offset=5`
